### PR TITLE
[BUGFIX #4] Start fails with error

### DIFF
--- a/lib/docker_sync/sync_strategy/rsync.rb
+++ b/lib/docker_sync/sync_strategy/rsync.rb
@@ -60,6 +60,7 @@ module Docker_Sync
         #args.push("--groupmap='*:#{@options['sync_group']}'") if @options.key?('sync_group')
         args.push("#{@options['src']}/") # add a trailing slash
         args.push("rsync://#{@options['sync_host_ip']}:#{@options['sync_host_port']}/volume")
+        return args
       end
 
       # starts a rsync docker container listening on the specific port

--- a/lib/docker_sync/sync_strategy/unison.rb
+++ b/lib/docker_sync/sync_strategy/unison.rb
@@ -67,6 +67,7 @@ module Docker_Sync
         if @options.key?('sync_user') || @options.key?('sync_group') || @options.key?('sync_groupid') || @options.key?('sync_userid')
           raise('Unison does not support sync_user, sync_group, sync_groupid or sync_userid - please use rsync if you need that')
         end
+        return args
       end
 
       def start_container


### PR DESCRIPTION
- Error: lib/docker_sync/sync_strategy/unison.rb:38:in `sync': undefined
  method `join' for nil:NilClass (NoMethodError)
- Fix: looks like sync_options return nothing