### PR TITLE
[BUGFIX #4] Start fails with error

### DIFF
--- a/lib/docker_sync/sync_strategy/rsync.rb
+++ b/lib/docker_sync/sync_strategy/rsync.rb
@@ -60,6 +60,7 @@ module Docker_Sync
         #args.push("--groupmap='*:#{@options['sync_group']}'") if @options.key?('sync_group')
         args.push("#{@options['src']}/") # add a trailing slash
         args.push("rsync://#{@options['sync_host_ip']}:#{@options['sync_host_port']}/volume")
+        return args
       end
 
       # starts a rsync docker container listening on the specific port

--- a/lib/docker_sync/sync_strategy/unison.rb
+++ b/lib/docker_sync/sync_strategy/unison.rb
@@ -67,6 +67,7 @@ module Docker_Sync
         if @options.key?('sync_user') || @options.key?('sync_group') || @options.key?('sync_groupid') || @options.key?('sync_userid')
           raise('Unison does not support sync_user, sync_group, sync_groupid or sync_userid - please use rsync if you need that')
         end
+        return args
       end
 
       def start_container


### PR DESCRIPTION
Not a ruby developer at all, but it looks like the function `sync_options` returns nothing, with this patch I got it working.

Resolve error:

    lib/docker_sync/sync_strategy/unison.rb:38:in `sync': undefined method `join' for nil:NilClass (NoMethodError)
	from /Users/mickaelperrin/tmp/docker_sync/lib/docker_sync/sync_strategy/unison.rb:93:in `start_container'
	from /Users/mickaelperrin/tmp/docker_sync/lib/docker_sync/sync_strategy/unison.rb:32:in `run'
	from /Users/mickaelperrin/tmp/docker_sync/lib/docker_sync/sync_process.rb:64:in `run'
	from /Users/mickaelperrin/tmp/docker_sync/lib/docker_sync/sync_manager.rb:103:in `block in run'
	from /Users/mickaelperrin/tmp/docker_sync/lib/docker_sync/sync_manager.rb:102:in `each'
	from /Users/mickaelperrin/tmp/docker_sync/lib/docker_sync/sync_manager.rb:102:in `run'
	from /Users/mickaelperrin/tmp/docker_sync/tasks/sync.thor:32:in `start'
	from /Users/mickaelperrin/.rvm/gems/ruby-2.2.1/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
	from /Users/mickaelperrin/.rvm/gems/ruby-2.2.1/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
	from /Users/mickaelperrin/.rvm/gems/ruby-2.2.1/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
	from /Users/mickaelperrin/.rvm/gems/ruby-2.2.1/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
	from ../../docker_sync/bin/docker-sync:11:in `<main>'