### PR TITLE
[FEATURE] unison > sync uid/gid numerically

### DIFF
--- a/lib/docker_sync/sync_strategy/unison.rb
+++ b/lib/docker_sync/sync_strategy/unison.rb
@@ -62,6 +62,9 @@ module Docker_Sync
         args.push(@options['src'])
         args.push('-auto')
         args.push('-batch')
+        args.push('-owner')
+        args.push('-group')
+        args.push('-numericids')
         args.push(@options['sync_args']) if @options.key?('sync_args')
         args.push("socket://#{@options['sync_host_ip']}:#{@options['sync_host_port']}/")
         args.push('-debug verbose') if @options['verbose']


### PR DESCRIPTION
Currently all unison sync is done under `root`.

This is an issue if the mounted folder is intended to be used with a non root user, like `www-data`.

This patch ensures that files are sync with the uid/gid of the host user, so that in container we can simply done a `usermod -u $(stat -c '%u' /mountedfolder) www-data`.

I don't know if it should be `default` comportment or if it needs a special flag.