### PR TITLE
[TASK] Unison Remove outdated warn about excludes

### DIFF
--- a/lib/docker_sync/sync_strategy/unison.rb
+++ b/lib/docker_sync/sync_strategy/unison.rb
@@ -55,7 +55,6 @@ module Docker_Sync
         args = []
 
         unless @options['sync_excludes'].nil?
-          say_status 'warning','Excludes are yet not implemented for unison!', :yellow
           args = @options['sync_excludes'].map { |pattern| "-ignore='Path #{pattern}'" } + args
         end
         args.push(@options['src'])


### PR DESCRIPTION
Forgot to remove the warning about unsupported excludes in unison